### PR TITLE
Documentation updates for v0.8.0

### DIFF
--- a/assets/js/header.coffee
+++ b/assets/js/header.coffee
@@ -102,10 +102,10 @@ class Header
         resolve version
         return
 
-      url = 'https://api.github.com/repos/molovo/zunit/releases/latest'
+      url = 'https://api.github.com/repos/zunit-zsh/zunit/releases/latest'
       if window.baseDomain isnt 'https://zunit.xyz'
         next = true
-        url  = 'https://api.github.com/repos/molovo/zunit/releases'
+        url  = 'https://api.github.com/repos/zunit-zsh/zunit/releases'
 
       # Fetch the list from the stored JSON file
       fetch url

--- a/docs/contributing/contributing-to-zunit.jade
+++ b/docs/contributing/contributing-to-zunit.jade
@@ -19,7 +19,7 @@ block docs-content
 
       As a user of ZUnit you're the perfect candidate to help us improve our documentation. Typo corrections, error fixes, better explanations, more examples, etc. Open issues for things that could be improved. Anything. Even improvements to this document.
 
-      Use the [`docs` label](https://github.com/molovo/zunit/labels/docs) to find suggestions for what we'd love to see more documentation on.
+      Use the [`docs` label](https://github.com/zunit-zsh/zunit/labels/docs) to find suggestions for what we'd love to see more documentation on.
 
       ### Improve issues
 
@@ -29,30 +29,30 @@ block docs-content
 
       We're always looking for more opinions on discussions in the issue tracker. It's a good opportunity to influence the future direction of ZUnit.
 
-      The [`question` label](https://github.com/molovo/zunit/labels/question) is a good place to find ongoing discussions.
+      The [`question` label](https://github.com/zunit-zsh/zunit/labels/question) is a good place to find ongoing discussions.
 
       ### Write code
 
       You can use issue labels to discover issues you could help out with:
 
-      * [`blocked` issues](https://github.com/molovo/zunit/labels/blocked) need help getting unstuck
-      * [`bug` issues](https://github.com/molovo/zunit/labels/bug) are known bugs we'd like to fix
-      * [`enhancement` issues](https://github.com/molovo/zunit/labels/enhancement) are features we're open to including
-      * [`performance` issues](https://github.com/molovo/zunit/labels/performance) track ideas on how to improve ZUnit’s performance
+      * [`blocked` issues](https://github.com/zunit-zsh/zunit/labels/blocked) need help getting unstuck
+      * [`bug` issues](https://github.com/zunit-zsh/zunit/labels/bug) are known bugs we'd like to fix
+      * [`enhancement` issues](https://github.com/zunit-zsh/zunit/labels/enhancement) are features we're open to including
+      * [`performance` issues](https://github.com/zunit-zsh/zunit/labels/performance) track ideas on how to improve ZUnit’s performance
 
-      The [`help wanted`](https://github.com/molovo/zunit/labels/help%20wanted) and [`good for beginner`](https://github.com/molovo/zunit/labels/good%20for%20beginner) labels are especially useful.
+      The [`help wanted`](https://github.com/zunit-zsh/zunit/labels/help%20wanted) and [`good for beginner`](https://github.com/zunit-zsh/zunit/labels/good%20for%20beginner) labels are especially useful.
 
-      You may find an issue is assigned, or has the [`assigned` label](https://github.com/molovo/zunit/labels/assigned). Please double-check before starting on this issue because somebody else is likely already working on it.
+      You may find an issue is assigned, or has the [`assigned` label](https://github.com/zunit-zsh/zunit/labels/assigned). Please double-check before starting on this issue because somebody else is likely already working on it.
 
-      We'd like to fix [`priority` issues](https://github.com/molovo/zunit/labels/priority) first. We'd love to see progress on [`low-priority` issues](https://github.com/molovo/zunit/labels/low%20priority) too. [`future` issues](https://github.com/molovo/zunit/labels/future) are those that we'd like to get to, but not anytime soon. Please check before working on these since we may not yet want to take on the burden of supporting those features.
+      We'd like to fix [`priority` issues](https://github.com/zunit-zsh/zunit/labels/priority) first. We'd love to see progress on [`low-priority` issues](https://github.com/zunit-zsh/zunit/labels/low%20priority) too. [`future` issues](https://github.com/zunit-zsh/zunit/labels/future) are those that we'd like to get to, but not anytime soon. Please check before working on these since we may not yet want to take on the burden of supporting those features.
 
       ### Hang out in our chat
 
-      We have a [chat](https://gitter.im/molovo/zunit). Jump in there and lurk, talk to us, and help others.
+      We have a [chat](https://gitter.im/zunit-zsh/zunit). Jump in there and lurk, talk to us, and help others.
 
       ## Submitting an issue
 
-      - The issue tracker is for issues. Use our [chat](https://gitter.im/molovo/zunit) for support.
+      - The issue tracker is for issues. Use our [chat](https://gitter.im/zunit-zsh/zunit) for support.
       - Search the issue tracker before opening an issue.
       - Ensure you're using the latest version of ZUnit.
       - Use a clear and descriptive title.

--- a/docs/contributing/zunit-next.jade
+++ b/docs/contributing/zunit-next.jade
@@ -11,7 +11,7 @@ block docs-content
     :marked
       ZUnit is in constant development, and as such we need members of the community who are willing to use the most cutting-edge version of ZUnit's codebase and help us improve it with bug reports, suggestions and comments.
 
-      ZUnit's [Github repository](https://github.com/molovo/zunit) will always contain a branch called `next`, which contains the code which will be included in the next official release of ZUnit. As well as this, documentation for the next release will always be live at [next.zunit.xyz](https://next.zunit.xyz).
+      ZUnit's [Github repository](https://github.com/zunit-zsh/zunit) will always contain a branch called `next`, which contains the code which will be included in the next official release of ZUnit. As well as this, documentation for the next release will always be live at [next.zunit.xyz](https://next.zunit.xyz).
 
       If you're interested in checking out ZUnit Next, take a look at the [installation instructions](https://next.zunit.xyz/docs/getting-started/installation) over on the ZUnit Next website.
 

--- a/docs/getting-started/installation.jade
+++ b/docs/getting-started/installation.jade
@@ -89,13 +89,11 @@ block docs-content
     if baseDomain === 'https://zunit.xyz'
       :marked
         ```bash
-        brew tap molovo/revolver
         brew install zunit-zsh/zunit/zunit
         ```
     else
       :marked
         ```bash
-        brew tap molovo/revolver
         brew install --devel zunit-zsh/zunit/zunit
         ```
 

--- a/docs/getting-started/installation.jade
+++ b/docs/getting-started/installation.jade
@@ -57,7 +57,7 @@ block docs-content
         zplug 'molovo/revolver', \
           as:command, \
           use:revolver
-        zplug 'molovo/zunit', \
+        zplug 'zunit-zsh/zunit', \
           as:command, \
           use:zunit, \
           hook-build:'./build.zsh'
@@ -72,7 +72,7 @@ block docs-content
         zplug 'molovo/revolver', \
           as:command, \
           use:revolver
-        zplug 'molovo/zunit', \
+        zplug 'zunit-zsh/zunit', \
           at:next, \
           as:command, \
           use:zunit, \
@@ -93,17 +93,17 @@ block docs-content
       curl -L https://raw.githubusercontent.com/molovo/color/master/color.zsh > /usr/local/bin/color
 
       # Install ZUnit into $path
-      curl -L https://github.com/molovo/zunit/releases/download/__version__/zunit > /usr/local/bin/zunit
+      curl -L https://github.com/zunit-zsh/zunit/releases/download/__version__/zunit > /usr/local/bin/zunit
 
       # Optional, install ZUnit ZSH completion into $fpath
-      curl -L https://github.com/molovo/zunit/releases/download/__version__/zunit.zsh-completion > "${fpath[1]}/_zunit"
+      curl -L https://github.com/zunit-zsh/zunit/releases/download/__version__/zunit.zsh-completion > "${fpath[1]}/_zunit"
       ```
 
   section
     :marked
       ### Building From Source
 
-      To build ZUnit from source, once you've installed the dependencies just clone the [git repository](https://github.com/molovo/zunit) and run the included `build.zsh` script. Once done, copy the `zunit` executable to somewhere in your `$path`.
+      To build ZUnit from source, once you've installed the dependencies just clone the [git repository](https://github.com/zunit-zsh/zunit) and run the included `build.zsh` script. Once done, copy the `zunit` executable to somewhere in your `$path`.
 
   feature.bump
     if baseDomain === 'https://zunit.xyz'
@@ -114,7 +114,7 @@ block docs-content
         curl -L https://raw.githubusercontent.com/molovo/color/master/color.zsh > /usr/local/bin/color
 
         # Build ZUnit from source
-        git clone https://github.com/molovo/zunit
+        git clone https://github.com/zunit-zsh/zunit
         cd zunit
         ./build.zsh
 
@@ -132,7 +132,7 @@ block docs-content
         curl -L https://raw.githubusercontent.com/molovo/color/master/color.zsh > /usr/local/bin/color
 
         # Build ZUnit from source
-        git clone https://github.com/molovo/zunit
+        git clone https://github.com/zunit-zsh/zunit
         cd zunit
         git checkout next
         ./build.zsh

--- a/docs/getting-started/installation.jade
+++ b/docs/getting-started/installation.jade
@@ -81,6 +81,26 @@ block docs-content
 
   section
     :marked
+      ### Installing with [Homebrew](https://brew.sh)
+
+      ZUnit and its dependencies can all be installed with Homebrew.
+
+  feature.bump
+    if baseDomain === 'https://zunit.xyz'
+      :marked
+        ```bash
+        brew tap molovo/revolver
+        brew install zunit-zsh/zunit/zunit
+        ```
+    else
+      :marked
+        ```bash
+        brew tap molovo/revolver
+        brew install --devel zunit-zsh/zunit/zunit
+        ```
+
+  section
+    :marked
       ### Installing Manually
 
       To install manually, install the dependencies, and then download the ZUnit executable straight into your `$path`.

--- a/docs/getting-started/installation.jade
+++ b/docs/getting-started/installation.jade
@@ -18,7 +18,7 @@ block docs-content
       ### Requirements
 
       * ZSH 4.3.12+
-      * The [color](https://github.com/molovo/color) and [revolver](https://github.com/molovo/revolver) executables.
+      * [Revolver](https://github.com/molovo/revolver)
 
   feature
 
@@ -50,10 +50,6 @@ block docs-content
     if baseDomain === 'https://zunit.xyz'
       :marked
         ```bash
-        zplug 'molovo/color', \
-          as:command, \
-          use:'color.zsh', \
-          rename-to:color
         zplug 'molovo/revolver', \
           as:command, \
           use:revolver
@@ -65,10 +61,6 @@ block docs-content
     else
       :marked
         ```bash
-        zplug 'molovo/color', \
-          as:command, \
-          use:'color.zsh', \
-          rename-to:color
         zplug 'molovo/revolver', \
           as:command, \
           use:revolver
@@ -106,9 +98,8 @@ block docs-content
   feature.bump.install--version-instructions
     :marked
       ```bash
-      # Install color and revolver
+      # Install revolver
       curl -L https://raw.githubusercontent.com/molovo/revolver/master/revolver > /usr/local/bin/revolver
-      curl -L https://raw.githubusercontent.com/molovo/color/master/color.zsh > /usr/local/bin/color
 
       # Install ZUnit into $path
       curl -L https://github.com/zunit-zsh/zunit/releases/download/__version__/zunit > /usr/local/bin/zunit
@@ -127,9 +118,8 @@ block docs-content
     if baseDomain === 'https://zunit.xyz'
       :marked
         ```bash
-        # Install color and revolver
+        # Install revolver
         curl -L https://raw.githubusercontent.com/molovo/revolver/master/revolver > /usr/local/bin/revolver
-        curl -L https://raw.githubusercontent.com/molovo/color/master/color.zsh > /usr/local/bin/color
 
         # Build ZUnit from source
         git clone https://github.com/zunit-zsh/zunit
@@ -145,9 +135,8 @@ block docs-content
     else
       :marked
         ```bash
-        # Install color and revolver
+        # Install revolver
         curl -L https://raw.githubusercontent.com/molovo/revolver/master/revolver > /usr/local/bin/revolver
-        curl -L https://raw.githubusercontent.com/molovo/color/master/color.zsh > /usr/local/bin/color
 
         # Build ZUnit from source
         git clone https://github.com/zunit-zsh/zunit

--- a/docs/usage/configuring-zunit.jade
+++ b/docs/usage/configuring-zunit.jade
@@ -23,6 +23,7 @@ block docs-content
       time_limit: 0
       fail_fast: false
       allow_risky: false
+      verbose: false
       ```
 
   section

--- a/docs/usage/configuring-zunit.jade
+++ b/docs/usage/configuring-zunit.jade
@@ -109,3 +109,15 @@ block docs-content
       # Tests without assertions will not result in failure
       allow_risky: true
       ```
+
+  section
+    :marked
+      #### verbose
+
+      If verbose is true, the full output of each test is printed to stdout
+
+  feature.bump
+    :marked
+      ```yaml
+      verbose: true
+      ```

--- a/docs/usage/running-tests.jade
+++ b/docs/usage/running-tests.jade
@@ -119,3 +119,14 @@ block docs-content
       zunit --time-limit 5
       ```
 
+  section
+    :marked
+      #### -\-verbose
+
+      If `--verbose` is set, the full output of each test is printed to stdout
+
+  feature.bump
+    :marked
+      ```bash
+      zunit --verbose
+      ```

--- a/docs/writing-tests/assertions.jade
+++ b/docs/writing-tests/assertions.jade
@@ -87,6 +87,30 @@ block docs-content
 
   section
     :marked
+      ### is_substring_of
+
+      Searches for the value within a defined string, and fails if it is not found.
+
+  feature.bump
+    :marked
+      ```zunit
+      assert 'unicorns' is_substring_of 'I love unicorns!'
+      ```
+
+  section
+    :marked
+      ### is_not_substring_of
+
+      Searches for the value within a defined string, and fails if it is found.
+
+  feature.bump
+    :marked
+      ```zunit
+      assert 'unicorns' is_not_substring_of 'I love rainbows!'
+      ```
+
+  section
+    :marked
       ### matches
 
       Compares the value against a PCRE-compliant regular expression, and fails the test if it does not match.

--- a/docs/writing-tests/assertions.jade
+++ b/docs/writing-tests/assertions.jade
@@ -39,6 +39,54 @@ block docs-content
 
   section
     :marked
+      ### is_positive
+
+      Checks an integer to ensure that it is positive, and fails the test if it is not.
+
+  feature.bump
+    :marked
+      ```zunit
+      assert 1 is_positive
+      ```
+
+  section
+    :marked
+      ### is_negative
+
+      Checks an integer to ensure that it is negative, and fails the test if it is not.
+
+  feature.bump
+    :marked
+      ```zunit
+      assert -1 is_negative
+      ```
+
+  section
+    :marked
+      ### is_greater_than
+
+      Compares two integers to ensure one is greater, and fails the test if it is not.
+
+  feature.bump
+    :marked
+      ```zunit
+      assert 2 is_greater_than 1
+      ```
+
+  section
+    :marked
+      ### is_less_than
+
+      Compares two integers to ensure one is lesser, and fails the test if it is not.
+
+  feature.bump
+    :marked
+      ```zunit
+      assert 1 is_less_than 2
+      ```
+
+  section
+    :marked
       ### same_as
 
       Compares two strings to ensure that they are equal, and fails the test if they are not

--- a/docs/writing-tests/test-syntax.jade
+++ b/docs/writing-tests/test-syntax.jade
@@ -125,3 +125,45 @@ block docs-content
         # Test code here
       }
       ```
+
+  section
+    :marked
+      ### Pass a test manually
+
+      If you want to pass a test manually, use the `pass` helper method. This will stop execution of the test immediately, and mark it as passed.
+
+  feature.bump
+    :marked
+      ```zunit
+      @test 'Test will pass' {
+        pass
+      }
+      ```
+
+  section
+    :marked
+      ### Fail a test manually
+
+      If you want to fail a test manually, use the `fail` helper method. This will stop execution of the test immediately, mark it as failed, and print the message passed to it.
+
+  feature.bump
+    :marked
+      ```zunit
+      @test 'Test will fail' {
+        fail 'Failed'
+      }
+      ```
+
+  section
+    :marked
+      ### Throw an error
+
+      If you want to throw an error manually, use the `error` helper method. This will stop execution of the test immediately, mark it as errored, and print the error message passed to it.
+
+  feature.bump
+    :marked
+      ```zunit
+      @test 'Test will error' {
+        error 'Something went wrong'
+      }
+      ```

--- a/news/zunit-next.jade
+++ b/news/zunit-next.jade
@@ -10,4 +10,4 @@ block news-content
   :marked
     I've made quite a few changes recently to make it easier for ZUnit users to get access to bleeding-edge features. From now on, I'll be keeping a `next` branch of the source open, containing the next release of ZUnit, which will be called ZUnit Next. As well as this, accompanying documentation for ZUnit Next will be available at [next.zunit.xyz](https://next.zunit.xyz), as well as instructions for downloading and installing this version of ZUnit.
 
-    If you plan on using ZUnit Next, there may be bugs and/or changes to functionality as the next stable release takes shape. If you do find bugs, please [raise an issue](https://github.com/molovo/zunit/issues), and be sure to mention that you are using ZUnit Next.
+    If you plan on using ZUnit Next, there may be bugs and/or changes to functionality as the next stable release takes shape. If you do find bugs, please [raise an issue](https://github.com/zunit-zsh/zunit/issues), and be sure to mention that you are using ZUnit Next.

--- a/package.json
+++ b/package.json
@@ -5,13 +5,13 @@
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/molovo/zunit-www"
+    "url": "https://github.com/zunit-zsh/www"
   },
   "author": "molovo",
   "bugs": {
-    "url": "https://github.com/molovo/zunit-www/issues"
+    "url": "https://github.com/zunit-zsh/www/issues"
   },
-  "homepage": "https://github.com/molovo/zunit-www",
+  "homepage": "https://github.com/zunit-zsh/www",
   "dependencies": {
     "autoprefixer": "^6.2.3",
     "coffee-script": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "jstransformer-marked": "^1.0.0",
     "marked": "0.3.x",
     "moment": "^2.15.2",
-    "node-sass": "^3.4.2",
+    "node-sass": "^4.5.3",
     "postcss": "^5.0.13",
     "roots": "^5.1.0",
     "roots-browserify": "^0.5.0",

--- a/views/includes/_chat.jade
+++ b/views/includes/_chat.jade
@@ -6,4 +6,4 @@ aside.chat
       You can get support and updates in our Gitter chat room
 
   .chat--cta
-    a.button(href='//gitter.im/molovo/zunit') Join the Conversation
+    a.button(href='//gitter.im/zunit-zsh/zunit') Join the Conversation

--- a/views/includes/_header.jade
+++ b/views/includes/_header.jade
@@ -14,7 +14,7 @@ nav.nav--main
       span.nav--main-install-version
     a.nav--main-docs-link(href=baseUrl + '/docs') Documentation
     a(href=baseUrl + '/news') News
-    a(href='https://github.com/molovo/zunit') Github
+    a(href='https://github.com/zunit-zsh/zunit') Github
 
   nav.nav--docs
     div

--- a/views/index.jade
+++ b/views/index.jade
@@ -27,5 +27,5 @@ block content
     .buttons
       a.button(href=baseUrl + '/docs')
         span Read the Documentation
-      a.button(href='https://github.com/molovo/zunit')
+      a.button(href='https://github.com/zunit-zsh/zunit')
         span View on Github

--- a/yarn.lock
+++ b/yarn.lock
@@ -3664,6 +3664,10 @@ lodash.merge@^4.4.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.0.tgz#69884ba144ac33fe699737a6086deffadd0f89c5"
 
+lodash.mergewith@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.mergewith/-/lodash.mergewith-4.6.0.tgz#150cf0a16791f5903b8891eab154609274bdea55"
+
 lodash.pairs@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/lodash.pairs/-/lodash.pairs-3.0.1.tgz#bbe08d5786eeeaa09a15c91ebf0dcb7d2be326a9"
@@ -3909,11 +3913,11 @@ minimist@0.0.8, minimist@~0.0.1:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
-minimist@1.1.x, minimist@1.x, minimist@^1.1.0, minimist@^1.1.3:
+minimist@1.1.x, minimist@1.x, minimist@^1.1.0:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.1.3.tgz#3bedfd91a92d39016fcfaa1c681e8faa1a1efda8"
 
-minimist@^1.2.0:
+minimist@^1.1.3, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
@@ -4069,9 +4073,9 @@ node-pre-gyp@^0.6.29:
     tar "~2.2.1"
     tar-pack "~3.3.0"
 
-node-sass@^3.4.2:
-  version "3.13.1"
-  resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-3.13.1.tgz#7240fbbff2396304b4223527ed3020589c004fc2"
+node-sass@^4.5.3:
+  version "4.5.3"
+  resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.5.3.tgz#d09c9d1179641239d1b97ffc6231fdcec53e1568"
   dependencies:
     async-foreach "^0.1.3"
     chalk "^1.1.1"
@@ -4082,13 +4086,15 @@ node-sass@^3.4.2:
     in-publish "^2.0.0"
     lodash.assign "^4.2.0"
     lodash.clonedeep "^4.3.2"
+    lodash.mergewith "^4.6.0"
     meow "^3.7.0"
     mkdirp "^0.5.1"
     nan "^2.3.2"
     node-gyp "^3.3.1"
     npmlog "^4.0.0"
-    request "^2.61.0"
+    request "^2.79.0"
     sass-graph "^2.1.1"
+    stdout-stream "^1.4.0"
 
 node-status-codes@^1.0.0:
   version "1.0.0"
@@ -5017,7 +5023,7 @@ replace-ext@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/replace-ext/-/replace-ext-1.0.0.tgz#de63128373fcbf7c3ccfa4de5a480c45a67958eb"
 
-request@2, request@^2.61.0, request@^2.74.0, request@^2.79.0, request@~2.81.0:
+request@2, request@^2.74.0, request@^2.79.0, request@~2.81.0:
   version "2.81.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.81.0.tgz#c6928946a0e06c5f8d6f8a9333469ffda46298a0"
   dependencies:
@@ -5652,6 +5658,12 @@ statuses@1, "statuses@>= 1.3.1 < 2", statuses@~1.3.0, statuses@~1.3.1:
 statuses@~1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.2.1.tgz#dded45cc18256d51ed40aec142489d5c61026d28"
+
+stdout-stream@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/stdout-stream/-/stdout-stream-1.4.0.tgz#a2c7c8587e54d9427ea9edb3ac3f2cd522df378b"
+  dependencies:
+    readable-stream "^2.0.1"
 
 stream-browserify@^2.0.0:
   version "2.0.1"


### PR DESCRIPTION
* [x] Add docs for `--verbose` CLI option
* [x] Add docs for new substring assertion methods
* [x] Add docs for new integer assertion methods
* [x] Add docs for new helper methods
* [x] Update repository URLs
* [x] Add homebrew installation instructions
* [x] Remove references to `color` dependency

See molovo/zunit#67